### PR TITLE
Exclude bulkhead module

### DIFF
--- a/spring-cloud-circuitbreaker-resilience4j/pom.xml
+++ b/spring-cloud-circuitbreaker-resilience4j/pom.xml
@@ -30,6 +30,12 @@
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-spring-boot2</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>resilience4j-bulkhead</artifactId>
+					<groupId>io.github.resilience4j</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>


### PR DESCRIPTION
Bulkhead support should be opt in by adding the module, removing the bulkhead module which is transitively brought in

Fixes #97 