### PR TITLE
Add properties support for reactive circuit breaker

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker-resilience4j.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker-resilience4j.adoc
@@ -94,6 +94,39 @@ public Customizer<ReactiveResilience4JCircuitBreakerFactory> slowCustomizer() {
 ----
 ====
 
+==== Circuit Breaker Properties Configuration
+
+You can configure `CircuitBreaker` and `TimeLimiter` instances in your application's configuration properties file.
+Property configuration has higher priority than Java `Customizer` configuration.
+
+====
+[source]
+----
+resilience4j.circuitbreaker:
+ instances:
+     backendA:
+         registerHealthIndicator: true
+         slidingWindowSize: 100
+     backendB:
+         registerHealthIndicator: true
+         slidingWindowSize: 10
+         permittedNumberOfCallsInHalfOpenState: 3
+         slidingWindowType: TIME_BASED
+         recordFailurePredicate: io.github.robwin.exception.RecordFailurePredicate
+
+resilience4j.timelimiter:
+ instances:
+     backendA:
+         timeoutDuration: 2s
+         cancelRunningFuture: true
+     backendB:
+         timeoutDuration: 1s
+         cancelRunningFuture: false
+----
+====
+
+For more information on Resilience4j property configuration, see https://resilience4j.readme.io/docs/getting-started-3#configuration[Resilience4J Spring Boot 2 Configuration].
+
 ==== Bulkhead pattern supporting
 If `resilience4j-bulkhead` is on the classpath, Spring Cloud CircuitBreaker will wrap all methods with a Resilience4j Bulkhead.
 You can disable the Resilience4j Bulkhead by setting `spring.cloud.circuitbreaker.bulkhead.resilience4j.enabled` to `false`.

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.util.List;
 
 import javax.annotation.PostConstruct;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * @author Ryan Baxter
  * @author Eric Bussieres
+ * @author Thomas Vitale
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(name = { "reactor.core.publisher.Mono", "reactor.core.publisher.Flux",
@@ -50,8 +53,10 @@ public class ReactiveResilience4JAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(ReactiveCircuitBreakerFactory.class)
-	public ReactiveResilience4JCircuitBreakerFactory reactiveResilience4JCircuitBreakerFactory() {
-		ReactiveResilience4JCircuitBreakerFactory factory = new ReactiveResilience4JCircuitBreakerFactory();
+	public ReactiveResilience4JCircuitBreakerFactory reactiveResilience4JCircuitBreakerFactory(
+			CircuitBreakerRegistry circuitBreakerRegistry, TimeLimiterRegistry timeLimiterRegistry) {
+		ReactiveResilience4JCircuitBreakerFactory factory = new ReactiveResilience4JCircuitBreakerFactory(
+				circuitBreakerRegistry, timeLimiterRegistry);
 		customizers.forEach(customizer -> customizer.customize(factory));
 		return factory;
 	}

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfigurationPropertyTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfigurationPropertyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.circuitbreaker.resilience4j;
+
+import java.time.Duration;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * @author Thomas Vitale
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ReactiveResilience4JAutoConfigurationPropertyTest.class)
+@EnableAutoConfiguration
+@ActiveProfiles(profiles = "test-properties")
+public class ReactiveResilience4JAutoConfigurationPropertyTest {
+
+	@Autowired
+	ReactiveResilience4JCircuitBreakerFactory factory;
+
+	@Test
+	public void testCircuitBreakerPropertiesPopulated() {
+		CircuitBreakerRegistry circuitBreakerRegistry = factory.getCircuitBreakerRegistry();
+		assertThat(circuitBreakerRegistry).isNotNull();
+		assertThat(circuitBreakerRegistry.find("test_circuit")).isPresent();
+		assertThat(
+				circuitBreakerRegistry.find("test_circuit").get().getCircuitBreakerConfig().getMinimumNumberOfCalls())
+						.isEqualTo(5);
+	}
+
+	@Test
+	public void testTimeLimiterPropertiesPopulated() {
+		TimeLimiterRegistry timeLimiterRegistry = factory.getTimeLimiterRegistry();
+		assertThat(timeLimiterRegistry).isNotNull();
+		assertThat(timeLimiterRegistry.find("test_circuit")).isPresent();
+		assertThat(timeLimiterRegistry.find("test_circuit").get().getTimeLimiterConfig().getTimeoutDuration())
+				.isEqualTo(Duration.ofSeconds(18));
+	}
+
+	@Test
+	public void testDefaultCircuitBreakerPropertiesPopulated() {
+		factory.create("default_circuitBreaker").run(Mono.just("result"));
+		CircuitBreakerRegistry circuitBreakerRegistry = factory.getCircuitBreakerRegistry();
+		assertThat(circuitBreakerRegistry).isNotNull();
+		assertThat(circuitBreakerRegistry.find("default_circuitBreaker")).isPresent();
+		assertThat(circuitBreakerRegistry.find("default_circuitBreaker").get().getCircuitBreakerConfig()
+				.getMinimumNumberOfCalls()).isEqualTo(20);
+	}
+
+	@Test
+	public void testDefaultTimeLimiterPropertiesPopulated() {
+		factory.create("default_circuitBreaker").run(Mono.just("result"));
+		TimeLimiterRegistry timeLimiterRegistry = factory.getTimeLimiterRegistry();
+		assertThat(timeLimiterRegistry).isNotNull();
+		assertThat(timeLimiterRegistry.find("default_circuitBreaker")).isPresent();
+		assertThat(timeLimiterRegistry.find("default_circuitBreaker").get().getTimeLimiterConfig().getTimeoutDuration())
+				.isEqualTo(Duration.ofMillis(150));
+	}
+
+}

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfigurationWithoutMetricsTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfigurationWithoutMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.circuitbreaker.resilience4j;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,13 +36,15 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Ryan Baxter
+ * @author Thomas Vitale
  */
 @RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions({ "micrometer-core-*.jar", "resilience4j-micrometer-*.jar" })
 public class ReactiveResilience4JAutoConfigurationWithoutMetricsTest {
 
 	static ReactiveResilience4JCircuitBreakerFactory circuitBreakerFactory = spy(
-			new ReactiveResilience4JCircuitBreakerFactory());
+			new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
+					TimeLimiterRegistry.ofDefaults()));
 
 	@Test
 	public void testWithoutMetrics() {


### PR DESCRIPTION
ReactiveResilience4JCircuitBreaker can now be configured through properties in the same way as its imperative counterpart.

Re-added documentation on how to work with configuration properties since the one added in #88 got lost.

Fixes gh-107