### PR TITLE
support group config on circutbreaker and timelimiter

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker-resilience4j.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker-resilience4j.adoc
@@ -96,9 +96,60 @@ public Customizer<ReactiveResilience4JCircuitBreakerFactory> slowCustomizer() {
 
 ==== Circuit Breaker Properties Configuration
 
-You can configure `CircuitBreaker` and `TimeLimiter` instances in your application's configuration properties file.
+You can configure `CircuitBreaker` and `TimeLimiter` configs or instances in your application's configuration properties file.
 Property configuration has higher priority than Java `Customizer` configuration.
 
+Descending priority from top to bottom.
+
+* Method(id) config - on specific method or operation
+* Service(group) config - on specific application service or operations
+* Global default config
+
+====
+[source,java]
+----
+ReactiveResilience4JCircuitBreakerFactory.create(String id, String groupName)
+Resilience4JCircuitBreakerFactory.create(String id, String groupName)
+----
+====
+
+===== Global Default Properties Configuration
+====
+[source]
+----
+resilience4j.circuitbreaker:
+    configs:
+        default:
+            registerHealthIndicator: true
+            slidingWindowSize: 50
+
+resilience4j.timelimiter:
+    configs:
+        default:
+            timeoutDuration: 5s
+            cancelRunningFuture: true
+----
+====
+
+===== Configs Properties Configuration
+====
+[source]
+----
+resilience4j.circuitbreaker:
+    configs:
+        groupA:
+            registerHealthIndicator: true
+            slidingWindowSize: 200
+
+resilience4j.timelimiter:
+    configs:
+        groupC:
+            timeoutDuration: 3s
+            cancelRunningFuture: true
+----
+====
+
+===== Instances Properties Configuration
 ====
 [source]
 ----
@@ -124,6 +175,12 @@ resilience4j.timelimiter:
          cancelRunningFuture: false
 ----
 ====
+
+
+* `ReactiveResilience4JCircuitBreakerFactory.create("backendA")` or `Resilience4JCircuitBreakerFactory.create("backendA")` will apply `instances backendA properties`
+* `ReactiveResilience4JCircuitBreakerFactory.create("backendA", "groupA")` or `Resilience4JCircuitBreakerFactory.create("backendA", "groupA")` will apply `instances backendA properties`
+* `ReactiveResilience4JCircuitBreakerFactory.create("backendC")` or `Resilience4JCircuitBreakerFactory.create("backendC")` will apply `global default properties`
+* `ReactiveResilience4JCircuitBreakerFactory.create("backendC", "groupC")` or `Resilience4JCircuitBreakerFactory.create("backendC", "groupC")` will apply `global default CircuitBreaker properties and config groupC TimeLimiter properties`
 
 For more information on Resilience4j property configuration, see https://resilience4j.readme.io/docs/getting-started-3#configuration[Resilience4J Spring Boot 2 Configuration].
 

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JCircuitBreaker.java
@@ -29,17 +29,24 @@ import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import org.springframework.cloud.client.circuitbreaker.Customizer;
 import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreaker;
 
+import static org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JCircuitBreaker.CIRCUIT_BREAKER_GROUP_TAG;
+
 /**
  * @author Ryan Baxter
  * @author Thomas Vitale
+ * @author 荒
  */
 public class ReactiveResilience4JCircuitBreaker implements ReactiveCircuitBreaker {
 
 	private final String id;
+
+	private final String groupName;
 
 	private final io.github.resilience4j.circuitbreaker.CircuitBreakerConfig circuitBreakerConfig;
 
@@ -56,19 +63,23 @@ public class ReactiveResilience4JCircuitBreaker implements ReactiveCircuitBreake
 			Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration config,
 			CircuitBreakerRegistry circuitBreakerRegistry,
 			Optional<Customizer<CircuitBreaker>> circuitBreakerCustomizer) {
-		this.id = id;
-		this.circuitBreakerConfig = config.getCircuitBreakerConfig();
-		this.circuitBreakerRegistry = circuitBreakerRegistry;
-		this.circuitBreakerCustomizer = circuitBreakerCustomizer;
-		this.timeLimiterConfig = config.getTimeLimiterConfig();
-		this.timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
+		this(id, id, config, circuitBreakerRegistry, TimeLimiterRegistry.ofDefaults(), circuitBreakerCustomizer);
 	}
 
+	@Deprecated
 	public ReactiveResilience4JCircuitBreaker(String id,
 			Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration config,
 			CircuitBreakerRegistry circuitBreakerRegistry, TimeLimiterRegistry timeLimiterRegistry,
 			Optional<Customizer<CircuitBreaker>> circuitBreakerCustomizer) {
+		this(id, id, config, circuitBreakerRegistry, timeLimiterRegistry, circuitBreakerCustomizer);
+	}
+
+	public ReactiveResilience4JCircuitBreaker(String id, String groupName,
+			Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration config,
+			CircuitBreakerRegistry circuitBreakerRegistry, TimeLimiterRegistry timeLimiterRegistry,
+			Optional<Customizer<CircuitBreaker>> circuitBreakerCustomizer) {
 		this.id = id;
+		this.groupName = groupName;
 		this.circuitBreakerConfig = config.getCircuitBreakerConfig();
 		this.circuitBreakerRegistry = circuitBreakerRegistry;
 		this.circuitBreakerCustomizer = circuitBreakerCustomizer;
@@ -78,17 +89,13 @@ public class ReactiveResilience4JCircuitBreaker implements ReactiveCircuitBreake
 
 	@Override
 	public <T> Mono<T> run(Mono<T> toRun, Function<Throwable, Mono<T>> fallback) {
-		io.github.resilience4j.circuitbreaker.CircuitBreaker defaultCircuitBreaker = circuitBreakerRegistry
-				.circuitBreaker(id, circuitBreakerConfig);
-		circuitBreakerCustomizer.ifPresent(customizer -> customizer.customize(defaultCircuitBreaker));
-		TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter(id, timeLimiterConfig);
-		Mono<T> toReturn = toRun.transform(CircuitBreakerOperator.of(defaultCircuitBreaker))
-				.timeout(timeLimiter.getTimeLimiterConfig().getTimeoutDuration())
+		Tuple2<CircuitBreaker, TimeLimiter> tuple = buildCircuitBreakerAndTimeLimiter();
+		Mono<T> toReturn = toRun.transform(CircuitBreakerOperator.of(tuple.getT1()))
+				.timeout(tuple.getT2().getTimeLimiterConfig().getTimeoutDuration())
 				// Since we are using the Mono timeout we need to tell the circuit breaker
 				// about the error
 				.doOnError(TimeoutException.class,
-						t -> defaultCircuitBreaker.onError(
-								timeLimiter.getTimeLimiterConfig().getTimeoutDuration().toMillis(),
+						t -> tuple.getT1().onError(tuple.getT2().getTimeLimiterConfig().getTimeoutDuration().toMillis(),
 								TimeUnit.MILLISECONDS, t));
 		if (fallback != null) {
 			toReturn = toReturn.onErrorResume(fallback);
@@ -98,22 +105,29 @@ public class ReactiveResilience4JCircuitBreaker implements ReactiveCircuitBreake
 
 	@Override
 	public <T> Flux<T> run(Flux<T> toRun, Function<Throwable, Flux<T>> fallback) {
-		io.github.resilience4j.circuitbreaker.CircuitBreaker defaultCircuitBreaker = circuitBreakerRegistry
-				.circuitBreaker(id, circuitBreakerConfig);
-		circuitBreakerCustomizer.ifPresent(customizer -> customizer.customize(defaultCircuitBreaker));
-		TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter(id, timeLimiterConfig);
-		Flux<T> toReturn = toRun.transform(CircuitBreakerOperator.of(defaultCircuitBreaker))
-				.timeout(timeLimiter.getTimeLimiterConfig().getTimeoutDuration())
+		Tuple2<CircuitBreaker, TimeLimiter> tuple = buildCircuitBreakerAndTimeLimiter();
+		Flux<T> toReturn = toRun.transform(CircuitBreakerOperator.of(tuple.getT1()))
+				.timeout(tuple.getT2().getTimeLimiterConfig().getTimeoutDuration())
 				// Since we are using the Flux timeout we need to tell the circuit breaker
 				// about the error
 				.doOnError(TimeoutException.class,
-						t -> defaultCircuitBreaker.onError(
-								timeLimiter.getTimeLimiterConfig().getTimeoutDuration().toMillis(),
+						t -> tuple.getT1().onError(tuple.getT2().getTimeLimiterConfig().getTimeoutDuration().toMillis(),
 								TimeUnit.MILLISECONDS, t));
 		if (fallback != null) {
 			toReturn = toReturn.onErrorResume(fallback);
 		}
 		return toReturn;
+	}
+
+	private Tuple2<CircuitBreaker, TimeLimiter> buildCircuitBreakerAndTimeLimiter() {
+		final io.vavr.collection.Map<String, String> tags = io.vavr.collection.HashMap.of(CIRCUIT_BREAKER_GROUP_TAG,
+				this.groupName);
+		CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker(id, circuitBreakerConfig, tags);
+		circuitBreakerCustomizer.ifPresent(customizer -> customizer.customize(circuitBreaker));
+		TimeLimiter timeLimiter = this.timeLimiterRegistry.find(this.id)
+				.orElseGet(() -> this.timeLimiterRegistry.find(this.groupName)
+						.orElseGet(() -> this.timeLimiterRegistry.timeLimiter(this.id, this.timeLimiterConfig, tags)));
+		return Tuples.of(circuitBreaker, timeLimiter);
 	}
 
 }

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfigurationPropertyTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfigurationPropertyTest.java
@@ -17,8 +17,11 @@
 package org.springframework.cloud.circuitbreaker.resilience4j;
 
 import java.time.Duration;
+import java.util.Optional;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,6 +84,61 @@ public class ReactiveResilience4JAutoConfigurationPropertyTest {
 		assertThat(timeLimiterRegistry.find("default_circuitBreaker")).isPresent();
 		assertThat(timeLimiterRegistry.find("default_circuitBreaker").get().getTimeLimiterConfig().getTimeoutDuration())
 				.isEqualTo(Duration.ofMillis(150));
+	}
+
+	@Test
+	public void testTestGroupCircuitBreakerPropertiesPopulated() {
+		factory.create("a_in_test_group", "test_group").run(Mono.just("result"));
+		CircuitBreakerRegistry circuitBreakerRegistry = factory.getCircuitBreakerRegistry();
+		Optional<CircuitBreaker> circuitBreaker = circuitBreakerRegistry.find("a_in_test_group");
+		assertThat(circuitBreaker).isPresent();
+		assertThat(circuitBreaker.get().getCircuitBreakerConfig().getMinimumNumberOfCalls()).isEqualTo(30);
+	}
+
+	@Test
+	public void testTestGroupTimeLimiterPropertiesPopulated() {
+		factory.create("a_in_test_group", "test_group").run(Mono.just("result"));
+		TimeLimiterRegistry timeLimiterRegistry = factory.getTimeLimiterRegistry();
+		Optional<TimeLimiter> timeLimiter = timeLimiterRegistry.find("a_in_test_group");
+		assertThat(timeLimiter).isPresent();
+		assertThat(timeLimiter.get().getTimeLimiterConfig().getTimeoutDuration()).isEqualTo(Duration.ofMillis(500));
+	}
+
+	@Test
+	public void testTestCircuitTimeLimiterPropertiesPopulated() {
+		factory.create("test_circuit", "test_group").run(Mono.just("result"));
+		TimeLimiterRegistry timeLimiterRegistry = factory.getTimeLimiterRegistry();
+		Optional<TimeLimiter> timeLimiter = timeLimiterRegistry.find("test_circuit");
+		assertThat(timeLimiter).isPresent();
+		assertThat(timeLimiter.get().getTimeLimiterConfig().getTimeoutDuration()).isEqualTo(Duration.ofSeconds(18));
+	}
+
+	@Test
+	public void testTestCircuitCircuitBreakerPropertiesPopulated() {
+		factory.create("test_circuit", "test_group").run(Mono.just("result"));
+		CircuitBreakerRegistry circuitBreakerRegistry = factory.getCircuitBreakerRegistry();
+		Optional<CircuitBreaker> circuitBreaker = circuitBreakerRegistry.find("test_circuit");
+		assertThat(circuitBreaker).isPresent();
+		assertThat(circuitBreaker.get().getCircuitBreakerConfig().getMinimumNumberOfCalls()).isEqualTo(5);
+	}
+
+	@Test
+	public void testTestIdCircuitBreakerPropertiesPopulated() {
+		factory.create("test_id", "test_group").run(Mono.just("result"));
+		CircuitBreakerRegistry circuitBreakerRegistry = factory.getCircuitBreakerRegistry();
+		Optional<CircuitBreaker> circuitBreaker = circuitBreakerRegistry.find("test_id");
+		assertThat(circuitBreaker).isPresent();
+		assertThat(circuitBreaker.get().getCircuitBreakerConfig().getMinimumNumberOfCalls()).isEqualTo(10);
+	}
+
+	@Test
+	public void testTestGroupInstanceTimeLimiterPropertiesPopulated() {
+		factory.create("a_in_test_group_instance", "test_group_instance").run(Mono.just("result"));
+		TimeLimiterRegistry timeLimiterRegistry = factory.getTimeLimiterRegistry();
+		assertThat(timeLimiterRegistry.find("a_in_test_group_instance")).isNotPresent();
+		Optional<TimeLimiter> timeLimiter = timeLimiterRegistry.find("test_group_instance");
+		assertThat(timeLimiter).isPresent();
+		assertThat(timeLimiter.get().getTimeLimiterConfig().getTimeoutDuration()).isEqualTo(Duration.ofMillis(600));
 	}
 
 }

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JAutoConfigurationPropertyTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JAutoConfigurationPropertyTest.java
@@ -17,10 +17,13 @@
 package org.springframework.cloud.circuitbreaker.resilience4j;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +38,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
  * @author Andrii Bohutskyi
+ * @author 荒
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Resilience4JAutoConfigurationPropertyTest.class)
@@ -112,6 +116,61 @@ public class Resilience4JAutoConfigurationPropertyTest {
 		assertThat(threadPoolBulkheadRegistry.find("default_circuitBreaker")).isPresent();
 		assertThat(threadPoolBulkheadRegistry.find("default_circuitBreaker").get().getBulkheadConfig()
 				.getMaxThreadPoolSize()).isEqualTo(50);
+	}
+
+	@Test
+	public void testTestGroupCircuitBreakerPropertiesPopulated() {
+		factory.create("a_in_test_group", "test_group").run(() -> "result");
+		CircuitBreakerRegistry circuitBreakerRegistry = factory.getCircuitBreakerRegistry();
+		Optional<CircuitBreaker> circuitBreaker = circuitBreakerRegistry.find("a_in_test_group");
+		assertThat(circuitBreaker).isPresent();
+		assertThat(circuitBreaker.get().getCircuitBreakerConfig().getMinimumNumberOfCalls()).isEqualTo(30);
+	}
+
+	@Test
+	public void testTestGroupTimeLimiterPropertiesPopulated() {
+		factory.create("a_in_test_group", "test_group").run(() -> "result");
+		TimeLimiterRegistry timeLimiterRegistry = factory.getTimeLimiterRegistry();
+		Optional<TimeLimiter> timeLimiter = timeLimiterRegistry.find("a_in_test_group");
+		assertThat(timeLimiter).isPresent();
+		assertThat(timeLimiter.get().getTimeLimiterConfig().getTimeoutDuration()).isEqualTo(Duration.ofMillis(500));
+	}
+
+	@Test
+	public void testTestCircuitTimeLimiterPropertiesPopulated() {
+		factory.create("test_circuit", "test_group").run(() -> "result");
+		TimeLimiterRegistry timeLimiterRegistry = factory.getTimeLimiterRegistry();
+		Optional<TimeLimiter> timeLimiter = timeLimiterRegistry.find("test_circuit");
+		assertThat(timeLimiter).isPresent();
+		assertThat(timeLimiter.get().getTimeLimiterConfig().getTimeoutDuration()).isEqualTo(Duration.ofSeconds(18));
+	}
+
+	@Test
+	public void testTestCircuitCircuitBreakerPropertiesPopulated() {
+		factory.create("test_circuit", "test_group").run(() -> "result");
+		CircuitBreakerRegistry circuitBreakerRegistry = factory.getCircuitBreakerRegistry();
+		Optional<CircuitBreaker> circuitBreaker = circuitBreakerRegistry.find("test_circuit");
+		assertThat(circuitBreaker).isPresent();
+		assertThat(circuitBreaker.get().getCircuitBreakerConfig().getMinimumNumberOfCalls()).isEqualTo(5);
+	}
+
+	@Test
+	public void testTestIdCircuitBreakerPropertiesPopulated() {
+		factory.create("test_id", "test_group").run(() -> "result");
+		CircuitBreakerRegistry circuitBreakerRegistry = factory.getCircuitBreakerRegistry();
+		Optional<CircuitBreaker> circuitBreaker = circuitBreakerRegistry.find("test_id");
+		assertThat(circuitBreaker).isPresent();
+		assertThat(circuitBreaker.get().getCircuitBreakerConfig().getMinimumNumberOfCalls()).isEqualTo(10);
+	}
+
+	@Test
+	public void testTestGroupInstanceTimeLimiterPropertiesPopulated() {
+		factory.create("a_in_test_group_instance", "test_group_instance").run(() -> "result");
+		TimeLimiterRegistry timeLimiterRegistry = factory.getTimeLimiterRegistry();
+		assertThat(timeLimiterRegistry.find("a_in_test_group_instance")).isNotPresent();
+		Optional<TimeLimiter> timeLimiter = timeLimiterRegistry.find("test_group_instance");
+		assertThat(timeLimiter).isPresent();
+		assertThat(timeLimiter.get().getTimeLimiterConfig().getTimeoutDuration()).isEqualTo(Duration.ofMillis(600));
 	}
 
 }

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/resources/application-test-properties.properties
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/resources/application-test-properties.properties
@@ -2,6 +2,11 @@ resilience4j.circuitbreaker.configs.default.minimumNumberOfCalls=20
 resilience4j.timelimiter.configs.default.timeout-duration=150ms
 resilience4j.thread-pool-bulkhead.configs.default.max-thread-pool-size=50
 
+resilience4j.circuitbreaker.configs.test_group.minimumNumberOfCalls=30
+resilience4j.circuitbreaker.configs.test_id.minimumNumberOfCalls=10
+resilience4j.timelimiter.configs.test_group.timeout-duration=500ms
+resilience4j.timelimiter.instances.test_group_instance.timeout-duration=600ms
+
 resilience4j.circuitbreaker.instances.test_circuit.minimumNumberOfCalls=5
 resilience4j.timelimiter.instances.test_circuit.timeout-duration=18s
 


### PR DESCRIPTION
Add support group/service config on Reative&Blocked CircuitBreaker.
* method(id) config - on specific method or operation
* Service(group) config - on specific application service or operations
* global default config

Descending priority from top to bottom.

