### PR TITLE
Fix Customizer bean typo in docs

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker-resilience4j.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker-resilience4j.adoc
@@ -13,7 +13,7 @@ You can disable the Resilience4J auto-configuration by setting
 
 ==== Default Configuration
 
-To provide a default configuration for all of your circuit breakers create a `Customize` bean that is passed a
+To provide a default configuration for all of your circuit breakers create a `Customizer` bean that is passed a
 `Resilience4JCircuitBreakerFactory` or `ReactiveResilience4JCircuitBreakerFactory`.
 The `configureDefault` method can be used to provide a default configuration.
 
@@ -46,7 +46,7 @@ public Customizer<ReactiveResilience4JCircuitBreakerFactory> defaultCustomizer()
 
 ==== Specific Circuit Breaker Configuration
 
-Similarly to providing a default configuration, you can create a `Customize` bean this is passed a
+Similarly to providing a default configuration, you can create a `Customizer` bean this is passed a
 `Resilience4JCircuitBreakerFactory` or `ReactiveResilience4JCircuitBreakerFactory`.
 
 ====
@@ -216,7 +216,7 @@ public Customizer<Resilience4jBulkheadProvider> defaultBulkheadCustomizer() {
 
 ==== Specific Bulkhead Configuration
 
-Similarly to proving a default 'Bulkhead' or 'ThreadPoolBulkhead' configuration, you can create a `Customize` bean this
+Similarly to proving a default 'Bulkhead' or 'ThreadPoolBulkhead' configuration, you can create a `Customizer` bean this
 is passed a `Resilience4jBulkheadProvider`.
 
 ====

--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker-spring-retry.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker-spring-retry.adoc
@@ -11,7 +11,7 @@ Both of these classes can be configured using `SpringRetryConfigBuilder`.
 
 ==== Default Configuration
 
-To provide a default configuration for all of your circuit breakers create a `Customize` bean that is passed a
+To provide a default configuration for all of your circuit breakers create a `Customizer` bean that is passed a
 `SpringRetryCircuitBreakerFactory`.
 The `configureDefault` method can be used to provide a default configuration.
 
@@ -28,7 +28,7 @@ public Customizer<SpringRetryCircuitBreakerFactory> defaultCustomizer() {
 
 ==== Specific Circuit Breaker Configuration
 
-Similarly to providing a default configuration, you can create a `Customize` bean this is passed a
+Similarly to providing a default configuration, you can create a `Customizer` bean this is passed a
 `SpringRetryCircuitBreakerFactory`.
 
 ====


### PR DESCRIPTION
Hi, all

A `Customize` bean maybe typo in document.
Is `Customizer` bean right?