### PR TITLE
Spring Cloud Circuit Breaker not auto closing Resilience4 ThreadPoolBulkhead

### DIFF
--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4jBulkheadProvider.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4jBulkheadProvider.java
@@ -128,9 +128,14 @@ public class Resilience4jBulkheadProvider {
 			return Bulkhead.decorateCompletionStage(bulkhead, () -> asyncCall);
 		}
 		else {
-			ThreadPoolBulkhead threadPoolBulkhead = threadPoolBulkheadRegistry.bulkhead(id,
-					configuration.getThreadPoolBulkheadConfig(), tags);
-			return threadPoolBulkhead.decorateSupplier(supplier);
+			try (ThreadPoolBulkhead threadPoolBulkhead = threadPoolBulkheadRegistry.bulkhead(id,
+					configuration.getThreadPoolBulkheadConfig(), tags)) {
+				return threadPoolBulkhead.decorateSupplier(supplier);
+			}
+			catch (final Exception ex) {
+				throw new RuntimeException("Not able to auto close ThreadPoolBulkhead in "
+						+ "Resilience4jBulkheadProvider#decorateBulkhead", ex);
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, the ThreadPoolBulkhead is not auto closing resources.

Tested by using Spring Cloud Circuit Breaker in a batch job, the batch hangs and never finishes as the bulkhead threads are not closed. When configure to use semaphore works fine.

Tested locally with this change, and service is able to properly close the threads.

More info here:
https://github.com/resilience4j/resilience4j/issues/1199