### PR TITLE
introduce disable-time-limiter property

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -253,6 +253,24 @@ resilience4j.timelimiter:
 
 For more information on Resilience4j property configuration, see https://resilience4j.readme.io/docs/getting-started-3#configuration[Resilience4J Spring Boot 2 Configuration].
 
+===== Disabling the TimeLimiter
+
+By default, the `TimeLimiter` is enabled and every execution is backed by a time limit. This time limit is either defined explicitly or the default time limit (provided by `io.github.resilience4j.timelimiter.TimeLimiterConfig#ofDefaults`) is used.
+
+The `TimeLimiter` can be globally disabled by setting the property `spring.cloud.circuitbreaker.resilience4j.disable-time-limiter` to `true`.
+
+[source,yaml]
+----
+spring:
+	cloud:
+		circuitbreaker:
+			resilience4j:
+				disable-time-limiter: true
+----
+
+This type of option is only provided on a global scope within the `spring-cloud-circuitbreaker` and applies to the
+basic and to the reactive circuitbreaker implementation.
+
 ==== Bulkhead pattern supporting
 If `resilience4j-bulkhead` is on the classpath, Spring Cloud CircuitBreaker will wrap all methods with a Resilience4j Bulkhead.
 You can disable the Resilience4j Bulkhead by setting `spring.cloud.circuitbreaker.bulkhead.resilience4j.enabled` to `false`.

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfiguration.java
@@ -54,9 +54,10 @@ public class ReactiveResilience4JAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(ReactiveCircuitBreakerFactory.class)
 	public ReactiveResilience4JCircuitBreakerFactory reactiveResilience4JCircuitBreakerFactory(
-			CircuitBreakerRegistry circuitBreakerRegistry, TimeLimiterRegistry timeLimiterRegistry) {
+			CircuitBreakerRegistry circuitBreakerRegistry, TimeLimiterRegistry timeLimiterRegistry,
+			Resilience4JConfigurationProperties resilience4JConfigurationProperties) {
 		ReactiveResilience4JCircuitBreakerFactory factory = new ReactiveResilience4JCircuitBreakerFactory(
-				circuitBreakerRegistry, timeLimiterRegistry);
+				circuitBreakerRegistry, timeLimiterRegistry, resilience4JConfigurationProperties);
 		customizers.forEach(customizer -> customizer.customize(factory));
 		return factory;
 	}

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JCircuitBreakerFactory.java
@@ -46,15 +46,25 @@ public class ReactiveResilience4JCircuitBreakerFactory extends
 
 	private TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
 
-	private Map<String, Customizer<CircuitBreaker>> circuitBreakerCustomizers = new HashMap<>();
+	private final Map<String, Customizer<CircuitBreaker>> circuitBreakerCustomizers = new HashMap<>();
+
+	private final Resilience4JConfigurationProperties resilience4JConfigurationProperties;
+
+	@Deprecated
+	public ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry circuitBreakerRegistry,
+		TimeLimiterRegistry timeLimiterRegistry) {
+		this(circuitBreakerRegistry, timeLimiterRegistry, null);
+	}
 
 	public ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry circuitBreakerRegistry,
-			TimeLimiterRegistry timeLimiterRegistry) {
+			TimeLimiterRegistry timeLimiterRegistry,
+			Resilience4JConfigurationProperties resilience4JConfigurationProperties) {
 		this.circuitBreakerRegistry = circuitBreakerRegistry;
 		this.timeLimiterRegistry = timeLimiterRegistry;
 		this.defaultConfiguration = id -> new Resilience4JConfigBuilder(id)
 				.circuitBreakerConfig(this.circuitBreakerRegistry.getDefaultConfig())
 				.timeLimiterConfig(this.timeLimiterRegistry.getDefaultConfig()).build();
+		this.resilience4JConfigurationProperties = resilience4JConfigurationProperties;
 	}
 
 	@Override
@@ -91,7 +101,14 @@ public class ReactiveResilience4JCircuitBreakerFactory extends
 		Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration config = new Resilience4JConfigBuilder(id)
 				.circuitBreakerConfig(circuitBreakerConfig).timeLimiterConfig(timeLimiterConfig).build();
 		return new ReactiveResilience4JCircuitBreaker(id, groupName, config, circuitBreakerRegistry,
-				timeLimiterRegistry, Optional.ofNullable(circuitBreakerCustomizers.get(id)));
+			timeLimiterRegistry, Optional.ofNullable(circuitBreakerCustomizers.get(id)), isDisableTimeLimiter());
+	}
+
+	private boolean isDisableTimeLimiter() {
+		if (resilience4JConfigurationProperties != null) {
+			return resilience4JConfigurationProperties.isDisableTimeLimiter();
+		}
+		return false;
 	}
 
 	@Override

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreaker.java
@@ -45,6 +45,7 @@ public class Resilience4JCircuitBreaker implements CircuitBreaker {
 	private final String id;
 
 	private final String groupName;
+	private final Map<String, String> tags;
 
 	private Resilience4jBulkheadProvider bulkheadProvider;
 
@@ -60,12 +61,26 @@ public class Resilience4JCircuitBreaker implements CircuitBreaker {
 
 	private final Optional<Customizer<io.github.resilience4j.circuitbreaker.CircuitBreaker>> circuitBreakerCustomizer;
 
+	private final boolean disableTimeLimiter;
+
+	@Deprecated
+	public Resilience4JCircuitBreaker(String id, String groupName,
+		io.github.resilience4j.circuitbreaker.CircuitBreakerConfig circuitBreakerConfig,
+		TimeLimiterConfig timeLimiterConfig, CircuitBreakerRegistry circuitBreakerRegistry,
+		TimeLimiterRegistry timeLimiterRegistry, ExecutorService executorService,
+		Optional<Customizer<io.github.resilience4j.circuitbreaker.CircuitBreaker>> circuitBreakerCustomizer,
+		Resilience4jBulkheadProvider bulkheadProvider) {
+		this(id, groupName, circuitBreakerConfig, timeLimiterConfig, circuitBreakerRegistry, timeLimiterRegistry,
+			executorService, circuitBreakerCustomizer, bulkheadProvider, false);
+	}
+
 	public Resilience4JCircuitBreaker(String id, String groupName,
 			io.github.resilience4j.circuitbreaker.CircuitBreakerConfig circuitBreakerConfig,
 			TimeLimiterConfig timeLimiterConfig, CircuitBreakerRegistry circuitBreakerRegistry,
 			TimeLimiterRegistry timeLimiterRegistry, ExecutorService executorService,
 			Optional<Customizer<io.github.resilience4j.circuitbreaker.CircuitBreaker>> circuitBreakerCustomizer,
-			Resilience4jBulkheadProvider bulkheadProvider) {
+			Resilience4jBulkheadProvider bulkheadProvider,
+			boolean disableTimeLimiter) {
 		this.id = id;
 		this.groupName = groupName;
 		this.circuitBreakerConfig = circuitBreakerConfig;
@@ -75,6 +90,8 @@ public class Resilience4JCircuitBreaker implements CircuitBreaker {
 		this.executorService = executorService;
 		this.circuitBreakerCustomizer = circuitBreakerCustomizer;
 		this.bulkheadProvider = bulkheadProvider;
+		this.disableTimeLimiter = disableTimeLimiter;
+		this.tags = Map.of(CIRCUIT_BREAKER_GROUP_TAG, this.groupName);
 	}
 
 	public Resilience4JCircuitBreaker(String id, String groupName,
@@ -90,40 +107,42 @@ public class Resilience4JCircuitBreaker implements CircuitBreaker {
 	@Override
 	public <T> T run(Supplier<T> toRun, Function<Throwable, T> fallback) {
 		final Map<String, String> tags = Map.of(CIRCUIT_BREAKER_GROUP_TAG, this.groupName);
-		TimeLimiter timeLimiter = this.timeLimiterRegistry.find(this.id)
-				.orElseGet(() -> this.timeLimiterRegistry.find(this.groupName)
-						.orElseGet(() -> this.timeLimiterRegistry.timeLimiter(this.id, this.timeLimiterConfig, tags)));
+		Optional<TimeLimiter> timeLimiter = loadTimeLimiter();
 		io.github.resilience4j.circuitbreaker.CircuitBreaker defaultCircuitBreaker = registry.circuitBreaker(this.id,
-				this.circuitBreakerConfig, tags);
+			this.circuitBreakerConfig, tags);
 		circuitBreakerCustomizer.ifPresent(customizer -> customizer.customize(defaultCircuitBreaker));
 		if (bulkheadProvider != null) {
 
 			if (executorService != null) {
 				Supplier<Future<T>> futureSupplier = () -> executorService.submit(toRun::get);
-				Callable<T> timeLimitedCall = TimeLimiter.decorateFutureSupplier(timeLimiter, futureSupplier);
+				/* conditionally wrap in time-limiter */
+				Callable<T> timeLimitedCall = timeLimiter.map(tl -> TimeLimiter.decorateFutureSupplier(tl, futureSupplier))
+					.orElse(() -> futureSupplier.get().get());
 				Callable<T> bulkheadCall = bulkheadProvider.decorateCallable(this.groupName, tags, timeLimitedCall);
 				Callable<T> circuitBreakerCall = io.github.resilience4j.circuitbreaker.CircuitBreaker
-						.decorateCallable(defaultCircuitBreaker, bulkheadCall);
+					.decorateCallable(defaultCircuitBreaker, bulkheadCall);
 				return getAndApplyFallback(circuitBreakerCall, fallback);
 			}
 			else {
 				Callable<T> bulkheadCall = bulkheadProvider.decorateCallable(this.groupName, tags, toRun::get);
 				Callable<T> circuitBreakerCall = io.github.resilience4j.circuitbreaker.CircuitBreaker
-						.decorateCallable(defaultCircuitBreaker, bulkheadCall);
+					.decorateCallable(defaultCircuitBreaker, bulkheadCall);
 				return getAndApplyFallback(circuitBreakerCall, fallback);
 			}
 		}
 		else {
 			if (executorService != null) {
 				Supplier<Future<T>> futureSupplier = () -> executorService.submit(toRun::get);
-				Callable<T> restrictedCall = TimeLimiter.decorateFutureSupplier(timeLimiter, futureSupplier);
+				/* conditionally wrap in time-limiter */
+				Callable<T> restrictedCall = timeLimiter.map(tl -> TimeLimiter.decorateFutureSupplier(tl, futureSupplier))
+					.orElse(() -> futureSupplier.get().get());
 				Callable<T> callable = io.github.resilience4j.circuitbreaker.CircuitBreaker
-						.decorateCallable(defaultCircuitBreaker, restrictedCall);
+					.decorateCallable(defaultCircuitBreaker, restrictedCall);
 				return getAndApplyFallback(callable, fallback);
 			}
 			else {
 				Supplier<T> decorator = io.github.resilience4j.circuitbreaker.CircuitBreaker
-						.decorateSupplier(defaultCircuitBreaker, toRun);
+					.decorateSupplier(defaultCircuitBreaker, toRun);
 				return getAndApplyFallback(decorator, fallback);
 			}
 		}
@@ -147,4 +166,12 @@ public class Resilience4JCircuitBreaker implements CircuitBreaker {
 		}
 	}
 
+	private Optional<TimeLimiter> loadTimeLimiter() {
+		if (disableTimeLimiter) {
+			return Optional.empty();
+		}
+		return Optional.of(this.timeLimiterRegistry.find(this.id)
+			.orElseGet(() -> this.timeLimiterRegistry.find(this.groupName)
+				.orElseGet(() -> this.timeLimiterRegistry.timeLimiter(this.id, this.timeLimiterConfig, this.tags))));
+	}
 }

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerFactory.java
@@ -172,7 +172,8 @@ public class Resilience4JCircuitBreakerFactory extends
 		else {
 			return new Resilience4JCircuitBreaker(id, groupName, circuitBreakerConfig, timeLimiterConfig,
 					circuitBreakerRegistry, timeLimiterRegistry, circuitBreakerExecutorService,
-					Optional.ofNullable(circuitBreakerCustomizers.get(id)), bulkheadProvider);
+					Optional.ofNullable(circuitBreakerCustomizers.get(id)), bulkheadProvider,
+					this.resilience4JConfigurationProperties.isDisableTimeLimiter());
 		}
 
 	}

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JConfigurationProperties.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JConfigurationProperties.java
@@ -32,6 +32,8 @@ public class Resilience4JConfigurationProperties {
 
 	private boolean disableThreadPool = false;
 
+	private boolean disableTimeLimiter = false;
+
 	public boolean isEnableGroupMeterFilter() {
 		return enableGroupMeterFilter;
 	}
@@ -64,4 +66,12 @@ public class Resilience4JConfigurationProperties {
 		this.disableThreadPool = disableThreadPool;
 	}
 
+
+	boolean isDisableTimeLimiter() {
+		return disableTimeLimiter;
+	}
+
+	void setDisableTimeLimiter(boolean disableTimeLimiter) {
+		this.disableTimeLimiter = disableTimeLimiter;
+	}
 }

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4jBulkheadProvider.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4jBulkheadProvider.java
@@ -154,8 +154,12 @@ public class Resilience4jBulkheadProvider {
 				|| (bulkheadRegistry.find(id).isPresent() && threadPoolBulkheadRegistry.find(id).isEmpty());
 	}
 
-	private <T> Callable<T> decorateTimeLimiter(final Supplier<CompletionStage<T>> supplier, TimeLimiter timeLimiter) {
+	private static <T> Callable<T> decorateTimeLimiter(final Supplier<? extends CompletionStage<T>> supplier, TimeLimiter timeLimiter) {
 		final Supplier<Future<T>> futureSupplier = () -> supplier.get().toCompletableFuture();
+		if (timeLimiter == null) {
+			/* execute without time-limiter */
+			return () -> futureSupplier.get().get();
+		}
 		return timeLimiter.decorateFutureSupplier(futureSupplier);
 	}
 

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfigurationWithoutMetricsTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfigurationWithoutMetricsTest.java
@@ -44,7 +44,7 @@ public class ReactiveResilience4JAutoConfigurationWithoutMetricsTest {
 
 	static ReactiveResilience4JCircuitBreakerFactory circuitBreakerFactory = spy(
 			new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
-					TimeLimiterRegistry.ofDefaults()));
+					TimeLimiterRegistry.ofDefaults(), new Resilience4JConfigurationProperties()));
 
 	@Test
 	public void testWithoutMetrics() {

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JCircuitBreakerTest.java
@@ -18,13 +18,17 @@ package org.springframework.cloud.circuitbreaker.resilience4j;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
+import org.springframework.cloud.client.circuitbreaker.NoFallbackAvailableException;
 import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,14 +42,14 @@ public class ReactiveResilience4JCircuitBreakerTest {
 	@Test
 	public void runMono() {
 		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
-				TimeLimiterRegistry.ofDefaults()).create("foo");
+				TimeLimiterRegistry.ofDefaults(), new Resilience4JConfigurationProperties()).create("foo");
 		assertThat(Mono.just("foobar").transform(cb::run).block()).isEqualTo("foobar");
 	}
 
 	@Test
 	public void runMonoWithFallback() {
 		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
-				TimeLimiterRegistry.ofDefaults()).create("foo");
+				TimeLimiterRegistry.ofDefaults(), new Resilience4JConfigurationProperties()).create("foo");
 		assertThat(Mono.error(new RuntimeException("boom")).transform(it -> cb.run(it, t -> Mono.just("fallback")))
 				.block()).isEqualTo("fallback");
 	}
@@ -53,7 +57,7 @@ public class ReactiveResilience4JCircuitBreakerTest {
 	@Test
 	public void runFlux() {
 		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
-				TimeLimiterRegistry.ofDefaults()).create("foo");
+				TimeLimiterRegistry.ofDefaults(), new Resilience4JConfigurationProperties()).create("foo");
 		assertThat(Flux.just("foobar", "hello world").transform(cb::run).collectList().block())
 				.isEqualTo(Arrays.asList("foobar", "hello world"));
 	}
@@ -61,9 +65,95 @@ public class ReactiveResilience4JCircuitBreakerTest {
 	@Test
 	public void runFluxWithFallback() {
 		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
-				TimeLimiterRegistry.ofDefaults()).create("foo");
+				TimeLimiterRegistry.ofDefaults(), new Resilience4JConfigurationProperties()).create("foo");
 		assertThat(Flux.error(new RuntimeException("boom")).transform(it -> cb.run(it, t -> Flux.just("fallback")))
 				.collectList().block()).isEqualTo(Collections.singletonList("fallback"));
 	}
 
+	/**
+	 * Run circuit breaker with default time limiter and expects everything to run without errors.
+	 */
+	@Test
+	public void runWithDefaultTimeLimiter() {
+		final TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
+		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
+			timeLimiterRegistry, new Resilience4JConfigurationProperties()).create("foo");
+
+		assertThat(Mono.fromCallable(() -> {
+					try {
+						/* sleep less than time limit allows us to */
+						TimeUnit.MILLISECONDS.sleep(Math.min(timeLimiterRegistry.getDefaultConfig().getTimeoutDuration()
+							.toMillis() / 2L, 0L));
+					}
+					catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new RuntimeException("thread got interrupted", e);
+					}
+					return "foobar";
+				})
+				.subscribeOn(Schedulers.single())
+				.transform(cb::run)
+				.block()
+		).isEqualTo("foobar");
+	}
+
+	/**
+	 * Run circuit breaker with default time limiter and expects the time limit to get exceeded.
+	 */
+	@Test(expected = NoFallbackAvailableException.class)
+	public void runWithDefaultTimeLimiterTooSlow() {
+		final TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
+		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
+			timeLimiterRegistry, new Resilience4JConfigurationProperties()).create("foo");
+
+		Mono.fromCallable(() -> {
+				try {
+					/* sleep longer than time limit allows us to */
+					TimeUnit.MILLISECONDS.sleep(Math.max(timeLimiterRegistry.getDefaultConfig().getTimeoutDuration().toMillis(), 100L) * 2);
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new RuntimeException("thread got interrupted", e);
+				}
+				return "foobar";
+			})
+			.subscribeOn(Schedulers.single())
+			.transform(cb::run)
+			.doOnSuccess(s -> {
+				throw new AssertionError("timeout did not occur");
+			})
+			.block();
+
+		Assert.fail("execution did not cause exception");
+	}
+
+	/**
+	 * Run circuit breaker with default time limiter and exceed time limit. Due to the disabled time limiter execution,
+	 * everything should finish without errors.
+	 */
+	@Test
+	public void runWithDisabledTimeLimiter() {
+		final TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
+		final Resilience4JConfigurationProperties resilience4JConfigurationProperties = new Resilience4JConfigurationProperties();
+		resilience4JConfigurationProperties.setDisableTimeLimiter(true);
+		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
+			timeLimiterRegistry, resilience4JConfigurationProperties).create("foo");
+
+		assertThat(Mono.fromCallable(() -> {
+					try {
+						/* sleep longer than timit limit allows us to */
+						TimeUnit.MILLISECONDS.sleep(Math.max(timeLimiterRegistry.getDefaultConfig().getTimeoutDuration()
+							.toMillis(), 100L) * 2);
+					}
+					catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new RuntimeException("thread got interrupted", e);
+					}
+					return "foobar";
+				})
+				.subscribeOn(Schedulers.single())
+				.transform(cb::run)
+				.block()
+		).isEqualTo("foobar");
+	}
 }

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JAutoConfigurationMetricsConfigRun.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JAutoConfigurationMetricsConfigRun.java
@@ -42,7 +42,7 @@ public class Resilience4JAutoConfigurationMetricsConfigRun {
 
 	static ReactiveResilience4JCircuitBreakerFactory reactiveCircuitBreakerFactory = spy(
 			new ReactiveResilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(),
-					TimeLimiterRegistry.ofDefaults()));
+					TimeLimiterRegistry.ofDefaults(), new Resilience4JConfigurationProperties()));
 
 	static Resilience4JCircuitBreakerFactory circuitBreakerFactory = spy(
 			new Resilience4JCircuitBreakerFactory(CircuitBreakerRegistry.ofDefaults(), TimeLimiterRegistry.ofDefaults(),


### PR DESCRIPTION
Provide and use the new configuration property `spring.cloud.circuitbreaker.resilience4j.disable-time-timiter` as intended by https://github.com/spring-cloud/spring-cloud-circuitbreaker/issues/174.

Setting the property to `true` disables the time limiting feature for both (default and reactive) implementations.