### PR TITLE
Configure annotation processor on compiler plugin

### DIFF
--- a/spring-cloud-circuitbreaker-resilience4j/pom.xml
+++ b/spring-cloud-circuitbreaker-resilience4j/pom.xml
@@ -110,11 +110,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>annotationProcessor</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-resttestclient</artifactId>
 			<scope>test</scope>
 		</dependency>
@@ -125,5 +120,20 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>


### PR DESCRIPTION
When using the `spring-cloud-circuitbreaker-resilience4j` we get the following warning from javac 

```
[INFO] — compiler:3.15.0:compile (default-compile) @ debix-test-utils ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 18 source files with javac [debug parameters target 21] to target\classes
[INFO] Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
```

This refers to [JDK-8306819: Consider disabling the compiler's default active annotation processing](https://bugs.openjdk.org/browse/JDK-8306819)

The issue is that `spring-boot-configuration-processor` in `spring-cloud-circuitbreaker-resilience4j` is set up like this

```xml
		<dependency>
			<groupId>org.springframework.boot</groupId>
			<artifactId>spring-boot-configuration-processor</artifactId>
			<scope>annotationProcessor</scope>
		</dependency>
```

This is likely the artifact from a Gradle migration. Maven does not know the `annotationProcessor` and outputs the following warning during the build. This will likely cause the build to fail on Maven 4.

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.springframework.cloud:spring-cloud-circuitbreaker-resilience4j:jar:5.0.3-SNAPSHOT
[WARNING] 'dependencies.dependency.scope' for org.springframework.boot:spring-boot-configuration-processor:jar must be one of [provided, compile, runtime, test, system] but is 'annotationProcessor'. @ line 114, column 11
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

This PR changes the annotation processor to be used according to [Configuring the Annotation Processor](https://docs.spring.io/spring-boot/specification/configuration-metadata/annotation-processor.html#appendix.configuration-metadata.annotation-processor.configuring) in the official documentation.